### PR TITLE
ensure all static methods and properties are forwarded

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -212,9 +212,10 @@ export function createProxy(id) {
     // ---- END extra methods ----
   }
 
+  //forward static properties and methods
   const originalComponent = Registry.get(id).component;
-  if (originalComponent.preload) {
-    proxyComponent.preload = originalComponent.preload;
+  for (let key in originalComponent) {
+    proxyComponent[key] = originalComponent[key];
   }
 
   return proxyComponent;

--- a/test/fixtures/mockComponentWithStaticStuff.js
+++ b/test/fixtures/mockComponentWithStaticStuff.js
@@ -1,3 +1,8 @@
+function setup(component) {
+  component.foo = 42;
+  component.bar = function () {}
+}
+
 function create_main_fragment() {
   return {
     c: function create() { },
@@ -32,8 +37,8 @@ let cls = class{
   destroy() {}
 }
 
-cls.preload = function(){
 
-}
+setup(cls);
+cls.preload = function () {}
 
 export default cls;

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -6,7 +6,7 @@ const { spy } = require('sinon');
 const { configure, getConfig, Registry, createProxy } = require('../index');
 const Component = require('./fixtures/mockComponent').default;
 const ErrorComponent = require('./fixtures/mockComponentWithError').default;
-const PreloadComponent = require('./fixtures/mockComponentWithPreload').default;
+const ComponentWithStatic = require('./fixtures/mockComponentWithStaticStuff').default;
 
 chai.use(sinonChai);
 const { expect } = chai;
@@ -33,7 +33,7 @@ describe('Config', function() {
 describe('Proxy', function() {
 
   const id = 'fixtures\\mockComponent.html';
-  const idPreload = 'fixtures\\mockComponentWithPreload.html';
+  const idStatic = 'fixtures\\mockComponentWithPreload.html';
   const allMethods = 'get,fire,observe,on,set,teardown,_recompute,_set,_mount,_unmount,destroy,_register,_rerender'.split(',');
   const straightProxiedMethods = allMethods.slice(0, 7);
   const proxiedMethods = allMethods.slice(0, 10);
@@ -43,7 +43,8 @@ describe('Proxy', function() {
   const SpiedComponent = spy(Component),
     SpiedComponent2 = spy(Component),
     SpiedErrorComponent = spy(ErrorComponent),
-    SpiedPreload = spy(PreloadComponent, 'preload');
+    SpiedPreload = spy(ComponentWithStatic, 'preload'),
+    SpiedBar = spy(ComponentWithStatic, 'bar');
 
   Registry.set(id, {
     rollback: null,
@@ -51,15 +52,15 @@ describe('Proxy', function() {
     instances: []
   });
 
-  Registry.set(idPreload, {
+  Registry.set(idStatic, {
     rollback: null,
-    component: PreloadComponent,
+    component: ComponentWithStatic,
     instances: []
   });
 
   const Wrapped = createProxy(id),
     wrappedComponent = new Wrapped({}),
-    PreloadWrapped = createProxy(idPreload);
+    PreloadWrapped = createProxy(idStatic);
 
   let methodSpies = {};
   proxiedMethods.forEach((method) => { methodSpies[method] = spy(wrappedComponent.proxyTarget, method); });
@@ -67,9 +68,15 @@ describe('Proxy', function() {
   const customMethodSpies = {};
   customMethods.forEach((method) => { customMethodSpies[method] = spy(wrappedComponent.proxyTarget, method); });
 
-  it('should forward calls to static preload method', function() {
+  it('should forward calls to static methods', function() {
     PreloadWrapped.preload();
+    PreloadWrapped.bar();
     expect(SpiedPreload).to.be.calledOnce;
+    expect(SpiedBar).to.be.calledOnce;
+  });
+
+  it('should forward static properties', function() {
+    expect(PreloadWrapped.foo).to.eq(42);
   });
 
   it('should contain the right component and instance in Registry', function() {

--- a/test/proxy.spec.js
+++ b/test/proxy.spec.js
@@ -60,7 +60,7 @@ describe('Proxy', function() {
 
   const Wrapped = createProxy(id),
     wrappedComponent = new Wrapped({}),
-    PreloadWrapped = createProxy(idStatic);
+    WrappedWithStatic = createProxy(idStatic);
 
   let methodSpies = {};
   proxiedMethods.forEach((method) => { methodSpies[method] = spy(wrappedComponent.proxyTarget, method); });
@@ -69,14 +69,14 @@ describe('Proxy', function() {
   customMethods.forEach((method) => { customMethodSpies[method] = spy(wrappedComponent.proxyTarget, method); });
 
   it('should forward calls to static methods', function() {
-    PreloadWrapped.preload();
-    PreloadWrapped.bar();
+    WrappedWithStatic.preload();
+    WrappedWithStatic.bar();
     expect(SpiedPreload).to.be.calledOnce;
     expect(SpiedBar).to.be.calledOnce;
   });
 
   it('should forward static properties', function() {
-    expect(PreloadWrapped.foo).to.eq(42);
+    expect(WrappedWithStatic.foo).to.eq(42);
   });
 
   it('should contain the right component and instance in Registry', function() {


### PR DESCRIPTION
Something I missed is, components can have static properties and methods set up via `setup()`.
And sometimes these are accessed from outside the component itself.

We do not forward these, so they become inaccessible.

This PR fixes that