### PR TITLE
Use ES6 proxies instead of manually creating a proxy

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -65,7 +65,8 @@ export function createProxy(id) {
   const handler = {
     construct(target, args) {
       console.log('CONSTRUCT', args, this);
-      return new Proxy(new target(...args), innerHandler);
+      this.id = id;
+      return this._register(args[0]);
     },
     get(target, prop, receiver){
       console.log(...arguments);
@@ -83,6 +84,19 @@ export function createProxy(id) {
     set(target, prop, val){
       console.log('SET', prop, val);
       return Reflect.set(...arguments);
+    },
+    _register(options){
+      const record = Registry.get(id);
+      this.proxyTarget = new Proxy(new record.component(options), innerHandler);
+      this.ref = (new Date).getTime();
+      Registry.set(id, record);
+      Registry.registerInstance(this);
+      console.log(this.id, this.ref);
+      return this.proxyTarget;
+    },
+    _rerender(){
+      console.log('re-render called');
+      console.log(this.id, this.ref);
     }
   };
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -40,6 +40,59 @@ and ensures resolution to the
 latest version of the component
 */
 export function createProxy(id) {
+  const innerHandler = {
+    construct(target, args) {
+      console.log('INNER CONSTRUCT', args, this);
+    },
+    get(target, prop, receiver) {
+      const targetValue = Reflect.get(...arguments);
+      if (typeof targetValue === 'function') {
+        return function (...args) {
+          console.log('INNER CALL', prop, args);
+          return targetValue.apply(this, args);
+        }
+      } else {
+        console.log('INNNER GET', prop, targetValue);
+        return targetValue;
+      }
+    },
+    set(target, prop, val){
+      console.log('INNERSET', prop, val);
+      return Reflect.set(...arguments);
+    }
+  };
+
+  const handler = {
+    construct(target, args) {
+      console.log('CONSTRUCT', args, this);
+      return new Proxy(new target(...args), innerHandler);
+    },
+    get(target, prop, receiver){
+      console.log(...arguments);
+      const targetValue = Reflect.get(...arguments);
+      if (typeof targetValue === 'function') {
+        return function (...args) {
+          console.log('CALL', prop, args);
+          return targetValue.apply(this, args);
+        }
+      } else {
+        console.log('GET', prop, targetValue);
+        return targetValue;
+      }
+    },
+    set(target, prop, val){
+      console.log('SET', prop, val);
+      return Reflect.set(...arguments);
+    }
+  };
+
+  const record = Registry.get(id);
+
+  return new Proxy(record.component, handler);
+};
+
+
+export function createProxy1(id) {
   const handledMethods = '_mount,_unmount,destroy'.split(',');
   const forwardedMethods = 'get,fire,observe,on,set,teardown,_recompute,_set,_bind'.split(',');
   class proxyComponent {


### PR DESCRIPTION
This is very rough and experimental at the moment, every test fails.

The reasoning behind using ES6 proxies is, that we don't have to keep an eye on the svelte API and try to closely mirror component methods and properties.
This allows svelte components to add or remove methods/props in the future without the need to also update this.
This way we will just need to trap the methods and properties we are interested in. The rest just work without any problems.

However ES6 proxies also come with a few caveats.
The biggest problem right now is, we cannot change the `target` of a proxy at runtime.
This means that we cannot swap components after HMR and still keep using the same proxy.

Might be solvable using multiple layers of Proxies. Let's see how it goes 😄 
