### PR TITLE
fixes #10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+###v1.1.8
+ - fix forwarded events from child components not being re-bound on reload [#10](https://github.com/ekhaled/svelte-dev-helper/issues/10)
+
 ###v1.1.7
  - fix handling of computed props that depend on other computed props [#8](https://github.com/ekhaled/svelte-dev-helper/issues/8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+###v1.1.7
+ - fix handling of computed props that depend on other computed props [#8](https://github.com/ekhaled/svelte-dev-helper/issues/8)
+
+###v1.1.6
+ - fix computed props are not re-computed on reload [#6](https://github.com/ekhaled/svelte-dev-helper/issues/6)
+
+###v1.1.5
+ - fix bound properties are not handled properly [sveltejs/svelte-loader#46](https://github.com/sveltejs/svelte-loader/issues/46)
+
+###v1.1.4
+ - fix forwarding of custom properties from proxied component
+
+###v1.1.3
+ - fix bug with component destruction
+ - add support for `preload` static method used by sapper
+
+###v1.1.2
+ - fix forwarding of custom methods from proxied component
+
+###v1.1.1
+ - bugfixes
+
+###v1.1.0
+ - add automated tests and liniting
+
+###v1.0.0 (initial release)

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -184,11 +184,23 @@ export function createProxy(id) {
         options = this.proxyTarget.options,
         oldstate = this.get(),
         isMounted = this.__mounted,
-        insertionPoint = this.__insertionPoint;
+        insertionPoint = this.__insertionPoint,
+        handlers = this.proxyTarget._handlers;
 
       this.destroy(true, true);
 
       this._register(options);
+
+      //re-attach event handlers
+      const self = this;
+      for (const ev in handlers) {
+        const _handlers = handlers[ev];
+        _handlers.forEach(function(item){
+          if(item.toString().includes('component.fire(')){
+            self.proxyTarget.on(ev, item);
+          }
+        });
+      }
 
       if (mountpoint && isMounted) {
         this.proxyTarget._fragment.c();

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -195,8 +195,8 @@ export function createProxy(id) {
       const self = this;
       for (const ev in handlers) {
         const _handlers = handlers[ev];
-        _handlers.forEach(function(item){
-          if(item.toString().includes('component.fire(')){
+        _handlers.forEach (function(item) {
+          if (item.toString().includes('component.fire(')) {
             self.proxyTarget.on(ev, item);
           }
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-dev-helper",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Helper for svelte components to ease development",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Reattaches all events that contain `component.fire`.

`component.fire` is only used by parent components to forward child events