### PR TITLE
Check that `this.proxyTarget` is defined before referencing it

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -53,7 +53,7 @@ export function createProxy(id) {
 
       this._register(options);
 
-      this._debugName = this.proxyTarget._debugName || getDebugName(this.id);
+      this._debugName = (this.proxyTarget && this.proxyTarget._debugName) || getDebugName(this.id);
 
       // ---- forwarded methods ----
       const self = this;


### PR DESCRIPTION
Addresses sveltejs/svelte-loader#74 as described in this comment https://github.com/sveltejs/svelte-loader/issues/74#issuecomment-681769365

It adds a check to make sure that `this.proxyTarget` is defined before referencing it